### PR TITLE
Feature: add version output

### DIFF
--- a/byoxshell/__init__.py
+++ b/byoxshell/__init__.py
@@ -3,6 +3,7 @@ import shlex
 import subprocess
 import sys
 
+__version__ = '0.1.0'
 
 state = {
     'cwd': os.getcwd(),
@@ -27,6 +28,10 @@ def execute(*args):
 
 
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] in ['-v', '--version']:
+        print(__version__)
+        sys.exit(0)
+
     try:
         while True:
             x = input("> ")

--- a/byoxshell/__init__.py
+++ b/byoxshell/__init__.py
@@ -10,7 +10,7 @@ state = {
 
 
 def execute(*args):
-    if len(args) == 0:
+    if not len(args):
         return
 
     if args[0] == 'exit':

--- a/byoxshell/__init__.py
+++ b/byoxshell/__init__.py
@@ -1,6 +1,7 @@
 import os
 import shlex
 import subprocess
+import sys
 
 
 state = {
@@ -32,3 +33,4 @@ def main():
             execute(*shlex.split(x))
     except EOFError:
         print("exit")
+        sys.exit(0)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup, find_packages
+from byoxshell import __version__
 
 setup(
     name='byoxshell',
-    version='0.0.1',
+    version=__version__,
     author='Heiko Hübscher',
     author_email='heiko.huebscher@gmail.com',
     description='a simple unix shell, following "build your own x"',


### PR DESCRIPTION
Just adding a simple version output when invoking the shell with `-v` or `--version`.
I chose to keep it in the main source as `__version__`, but it can be anywhere, I assume.

This also introduces a more reliable `sys.exit(...)` [behaviour](https://docs.python.org/3/library/sys.html#sys.exit), which honors cleanup stuff after try/catch blocks, apparently.

(PS: i'm fully aware of [argparse](https://docs.python.org/3/library/argparse.html) which could be used for fancier stuff and a generated `-h` or `--help` output :-) )